### PR TITLE
Upgrade to buildkite 3.29

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Buildkite
+Copyright (c) 2021 Buildkite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use the formulae, tap this repository into your home brew:
 brew tap buildkite/buildkite
 ```
 
-This repository will have been cloned into your Homebrew’s `Libray/Taps` directory (most commonly `/usr/local/Homebrew/Library/Taps`), and whenever you do a `brew update` Homebrew will also update this tap (using `git pull`) and you’ll have the latest versions of the formulae.
+This repository will have been cloned into your Homebrew’s `Library/Taps` directory (most commonly `/usr/local/Homebrew/Library/Taps`), and whenever you do a `brew update` Homebrew will also update this tap (using `git pull`) and you’ll have the latest versions of the formulae.
 
 ## buildkite-agent
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ This repository will have been cloned into your Homebrew’s `Libray/Taps` direc
 To install [buildkite-agent](https://github.com/buildkite/agent):
 
 ```bash
-brew install --token='your-agent-token-here' buildkite-agent
+brew install buildkite-agent
 ```
 
-You can find your agent token on your "Agents" page in Buildkite.
+You then need to configure your agent token, which you can find your agent token on your "Agents" page in Buildkite:
+
+```bash
+sed -i '' "s/xxx/INSERT-YOUR-AGENT-TOKEN-HERE/g" "$(brew --prefix)"/etc/buildkite-agent/buildkite-agent.cfg
+```
 
 If you want it start on login follow the `brew install` instructions to install the LaunchAgent plist. You’ll also want to make sure your PC is set to automatically login (the agent won’t launch until you've logged in) and you’ve prevented your machine from going to sleep.
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 A collection of [Buildkite](https://buildkite.com/) formulae for [Homebrew](http://brew.sh), a package manager for macOS.
 
-To use the formulae, tap this repository into your home brew:
+## How do I install these formulae?
+
+`brew install buildkite/buildkite/<formula>`
+
+Or `brew tap buildkite/buildkite` and then `brew install <formula>`.
+
+## Available Formulae
+
+- [`buildkite-agent`](https://github.com/buildkite/agent) (Please see [installation notes](#buildkite-agent))
+- [Buildkite CLI](https://github.com/buildkite/cli)
+- [`terminal-to-html`](https://github.com/buildkite/terminal-to-html)
+
+### Notes for `buildkite-agent`
+
+To install [`buildkite-agent`](https://github.com/buildkite/agent):
 
 ```bash
-brew tap buildkite/buildkite
-```
-
-This repository will have been cloned into your Homebrew’s `Library/Taps` directory (most commonly `/usr/local/Homebrew/Library/Taps`), and whenever you do a `brew update` Homebrew will also update this tap (using `git pull`) and you’ll have the latest versions of the formulae.
-
-## buildkite-agent
-
-### Installing
-
-To install [buildkite-agent](https://github.com/buildkite/agent):
-
-```bash
-brew install buildkite-agent
+brew install buildkite/buildkite/buildkite-agent
 ```
 
 You then need to configure your agent token, which you can find your agent token on your "Agents" page in Buildkite:
@@ -30,8 +32,12 @@ If you want it start on login follow the `brew install` instructions to install 
 
 Using a LaunchAgent instead of a LaunchDaemon does require a user login, but it allows your tests to use GUI tools (such as the iOS Simulator) and avoids any file permissions problems.
 
-### Upgrading
+You can upgrade the agent using these commands:
 
 ```bash
 brew update && brew upgrade buildkite-agent
 ```
+
+## For further information about Homebrew
+
+`brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,13 +3,13 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.28.1"
+    version "3.29.0"
     if Hardware::CPU.arm?
-      url     "https://github.com/buildkite/agent/releases/download/v3.28.1/buildkite-agent-darwin-arm64-3.28.1.tar.gz"
-      sha256  "dd6486b5eca0c3b9fde2770f652c518576c693520c10146062955c97a66dff21"
+      url     "https://github.com/buildkite/agent/releases/download/v3.29.0/buildkite-agent-darwin-arm64-3.29.0.tar.gz"
+      sha256  "dde6a121a66db382833705c52a7758a921e4f6afcfb4842771327b262c0c7f1f"
     else
-      url     "https://github.com/buildkite/agent/releases/download/v3.28.1/buildkite-agent-darwin-amd64-3.28.1.tar.gz"
-      sha256  "d5f9f1042f8e5b726b778d70bddc3cc1054e7f18c773ba4ef5a0df8c2aea7282"
+      url     "https://github.com/buildkite/agent/releases/download/v3.29.0/buildkite-agent-darwin-amd64-3.29.0.tar.gz"
+      sha256  "540c111963808dd62b635dc8e5a686c872fc8fdab483d42aa001688fafd9f054"
     end
   end
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,9 +3,9 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.25.0"
-    url     "https://github.com/buildkite/agent/releases/download/v3.25.0/buildkite-agent-darwin-amd64-3.25.0.tar.gz"
-    sha256  "3e613033dc07597b6030b601a144588cf154b4f9c7e6fea1ddd9ccca390b4389"
+    version "3.26.0"
+    url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
+    sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
   end
 
   def agent_etc

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,13 +3,13 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.26.0"
+    version "3.27.0"
     if Hardware::CPU.arm?
-      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-arm64-3.26.0.tar.gz"
-      sha256  "92d731d04912b3de0eb03fe849a0f9eb75554c22ca538a5f388ce3cc66f923e8"
+      url     "https://github.com/buildkite/agent/releases/download/v3.27.0/buildkite-agent-darwin-arm64-3.27.0.tar.gz"
+      sha256  "dc17560f62171393daf85f773db3fa5d0da04c86f81590d3a8a8d1c38167ef73"
     else
-      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
-      sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
+      url     "https://github.com/buildkite/agent/releases/download/v3.27.0/buildkite-agent-darwin-amd64-3.27.0.tar.gz"
+      sha256  "bfce8951f86048a6df82543064f536bec4e4651b765ea3f13a29952148e26a1a"
     end
   end
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -4,7 +4,7 @@ class BuildkiteAgent < Formula
 
   stable do
     version "3.26.0"
-    if Hardware::CPU.physical_cpu_arm64?
+    if Hardware::CPU.arm?
       url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-arm64-3.26.0.tar.gz"
       sha256  "92d731d04912b3de0eb03fe849a0f9eb75554c22ca538a5f388ce3cc66f923e8"
     else

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -3,13 +3,13 @@ class BuildkiteAgent < Formula
   homepage "https://buildkite.com/docs/agent"
 
   stable do
-    version "3.27.0"
+    version "3.28.1"
     if Hardware::CPU.arm?
-      url     "https://github.com/buildkite/agent/releases/download/v3.27.0/buildkite-agent-darwin-arm64-3.27.0.tar.gz"
-      sha256  "dc17560f62171393daf85f773db3fa5d0da04c86f81590d3a8a8d1c38167ef73"
+      url     "https://github.com/buildkite/agent/releases/download/v3.28.1/buildkite-agent-darwin-arm64-3.28.1.tar.gz"
+      sha256  "dd6486b5eca0c3b9fde2770f652c518576c693520c10146062955c97a66dff21"
     else
-      url     "https://github.com/buildkite/agent/releases/download/v3.27.0/buildkite-agent-darwin-amd64-3.27.0.tar.gz"
-      sha256  "bfce8951f86048a6df82543064f536bec4e4651b765ea3f13a29952148e26a1a"
+      url     "https://github.com/buildkite/agent/releases/download/v3.28.1/buildkite-agent-darwin-amd64-3.28.1.tar.gz"
+      sha256  "d5f9f1042f8e5b726b778d70bddc3cc1054e7f18c773ba4ef5a0df8c2aea7282"
     end
   end
 

--- a/buildkite-agent.rb
+++ b/buildkite-agent.rb
@@ -4,8 +4,13 @@ class BuildkiteAgent < Formula
 
   stable do
     version "3.26.0"
-    url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
-    sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
+    if Hardware::CPU.physical_cpu_arm64?
+      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-arm64-3.26.0.tar.gz"
+      sha256  "92d731d04912b3de0eb03fe849a0f9eb75554c22ca538a5f388ce3cc66f923e8"
+    else
+      url     "https://github.com/buildkite/agent/releases/download/v3.26.0/buildkite-agent-darwin-amd64-3.26.0.tar.gz"
+      sha256  "8a2f78aad0791ebe41a546a6c17b71560852a439ba311d541d63073410645b2d"
+    end
   end
 
   def agent_etc

--- a/cli.rb
+++ b/cli.rb
@@ -2,12 +2,12 @@ class Cli < Formula
   desc "A command-line tool for working with Buildkite"
   homepage "https://github.com/buildkite/cli"
 
-  version "0.2.0"
-  url "https://github.com/buildkite/cli/releases/download/v0.2.0/bk-darwin-amd64-0.2.0"
-  sha256 "fd98d21bce1ae8d47bec7b27337ecfb7f7829f99cd155fb532167b53df5e1816"
+  version "1.1.0"
+  url "https://github.com/buildkite/cli/releases/download/v1.1.0/bk-darwin-amd64-1.1.0"
+  sha256 "580e595c67be43d95ecfd4525c0d0070ea85e8d288370af56ae6d3163c5164f3"
 
   def install
-    bin.install "bk-darwin-amd64-0.2.0" => "bk"
+    bin.install "bk-darwin-amd64-1.1.0" => "bk"
   end
 
   def caveats; <<~EOS

--- a/terminal-to-html.rb
+++ b/terminal-to-html.rb
@@ -1,0 +1,25 @@
+class TerminalToHtml < Formula
+  desc "Converts arbitrary shell output (with ANSI) into beautifully rendered HTML"
+  homepage "https://github.com/buildkite/terminal-to-html"
+
+  version "3.6.1"
+  if Hardware::CPU.arm?
+    url     "https://github.com/buildkite/terminal-to-html/releases/download/v3.6.1/terminal-to-html-3.6.1-darwin-arm64.gz"
+    sha256  "667d164e8dbc4f231f61892a23dac18ac7ca2b911d1b60e5b975b762b48e9718"
+  else
+    url     "https://github.com/buildkite/terminal-to-html/releases/download/v3.6.1/terminal-to-html-3.6.1-darwin-amd64.gz"
+    sha256  "45275d2bdd1fa1e9ea730a55435ca4991cd8771d997d353a3d469aa25fcbffce"
+  end
+
+  def install
+    if Hardware::CPU.arm?
+      bin.install "terminal-to-html-#{version}-darwin-arm64" => "terminal-to-html"
+    else
+      bin.install "terminal-to-html-#{version}-darwin-amd64" => "terminal-to-html"
+    end
+  end
+
+  test do
+    system "#{bin}/terminal-to-html", "--help"
+  end
+end


### PR DESCRIPTION
This will include changes in buildkite 3.28.1 for annotation removal, which would be useful for granular test reporting